### PR TITLE
ADD (Linux-x86_64): bits/wchar.h limits for `wchar_t` and `wint_t`

### DIFF
--- a/plat/Linux-x86_64/h/bits/wchar.h
+++ b/plat/Linux-x86_64/h/bits/wchar.h
@@ -1,0 +1,9 @@
+#ifndef __BITS_WCHAR_H__
+#define __BITS_WCHAR_H__
+
+#define WCHAR_MAX (0xffffffffu+L'\0')
+#define WCHAR_MIN (0x00000000u+L'\0')
+#define WINT_MAX  (0xffffffffu) 
+#define WINT_MIN  (0x00000000u)
+
+#endif


### PR DESCRIPTION
- Included definitions for `WCHAR_MAX`, `WCHAR_MIN`, `WINT_MAX`, and `WINT_MIN`.