### PR TITLE
ADD (Linux-x86_64): Implemented errno and __errno_location

### DIFF
--- a/plat/Linux-x86_64/core/errno.s
+++ b/plat/Linux-x86_64/core/errno.s
@@ -1,0 +1,11 @@
+.section .tbss,"awT",@nobits
+.type  errno, @object
+.size  errno, 4
+.globl errno
+errno: .long  0
+
+.section .text
+.globl __errno_location
+__errno_location:
+	movq %fs:errno@tpoff,%rax
+	ret


### PR DESCRIPTION
Thread local storage errno and the function which returns it location on thread local section for the current thread.